### PR TITLE
Optimize config flow to avoid spurious touchscreen prompts

### DIFF
--- a/custom_components/snapmaker/config_flow.py
+++ b/custom_components/snapmaker/config_flow.py
@@ -43,11 +43,13 @@ class SnapmakerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(host)
             self._abort_if_unique_id_configured()
 
-            # Validate the connection
+            # Connectivity-only check — avoids triggering a touchscreen prompt
             snapmaker = SnapmakerDevice(host)
             try:
-                result = await self.hass.async_add_executor_job(snapmaker.update)
-                if snapmaker.available:
+                online = await self.hass.async_add_executor_job(
+                    snapmaker.check_reachability
+                )
+                if online:
                     # Device is online, proceed to token authorization
                     return await self._validate_and_authorize(
                         host, snapmaker.model or host
@@ -79,27 +81,30 @@ class SnapmakerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # User has confirmed, now generate token
             snapmaker = SnapmakerDevice(host)
             try:
-                # Generate token with polling (default: 18 attempts × 10s = 3 minutes)
+                # Generate token with polling (default: 18 attempts × 10s = 3 minutes).
+                # On success generate_token() sets _token and _connected=True on this
+                # instance, so the subsequent update() skips the reconnect POST.
                 token = await self.hass.async_add_executor_job(snapmaker.generate_token)
 
                 if token:
-                    # Validate the token works before persisting it
-                    test_device = SnapmakerDevice(host, token=token)
+                    # Reuse the same instance — _connected is already True so
+                    # update() goes straight to _get_status() without sending
+                    # another POST that would trigger a new touchscreen prompt.
                     try:
-                        await self.hass.async_add_executor_job(test_device.update)
-                        if test_device.token_invalid:
+                        await self.hass.async_add_executor_job(snapmaker.update)
+                        if snapmaker.token_invalid:
                             _LOGGER.error(
                                 "Generated token is invalid on first use for %s. "
                                 "Device may have rejected the token or requires re-approval.",
                                 host,
                             )
                             errors["base"] = "auth_failed"
-                        elif not test_device.available:
+                        elif not snapmaker.available:
                             _LOGGER.warning(
                                 "Device not available after token generation for %s. "
                                 "Device status: %s",
                                 host,
-                                test_device.status,
+                                snapmaker.status,
                             )
                             errors["base"] = "cannot_connect"
                         else:
@@ -166,11 +171,13 @@ class SnapmakerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(host)
         self._abort_if_unique_id_configured()
 
-        # Validate the connection
+        # Connectivity-only check — avoids triggering a touchscreen prompt
         snapmaker = SnapmakerDevice(host)
         try:
-            result = await self.hass.async_add_executor_job(snapmaker.update)
-            if snapmaker.available:
+            online = await self.hass.async_add_executor_job(
+                snapmaker.check_reachability
+            )
+            if online:
                 # Device is online, proceed to token authorization
                 return await self._validate_and_authorize(host, snapmaker.model or host)
         except Exception:
@@ -186,11 +193,13 @@ class SnapmakerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         host = self.context["host"]
 
         if user_input is not None:
-            # Validate the connection again
+            # Connectivity-only check — avoids triggering a touchscreen prompt
             snapmaker = SnapmakerDevice(host)
             try:
-                result = await self.hass.async_add_executor_job(snapmaker.update)
-                if snapmaker.available:
+                online = await self.hass.async_add_executor_job(
+                    snapmaker.check_reachability
+                )
+                if online:
                     # Device is online, proceed to token authorization
                     return await self._validate_and_authorize(
                         host, snapmaker.model or host
@@ -296,11 +305,13 @@ class SnapmakerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         host = self.context.get("host")
 
         if user_input is not None:
-            # Validate device is still online
+            # Connectivity-only check — avoids triggering a touchscreen prompt
             snapmaker = SnapmakerDevice(host)
             try:
-                result = await self.hass.async_add_executor_job(snapmaker.update)
-                if snapmaker.available:
+                online = await self.hass.async_add_executor_job(
+                    snapmaker.check_reachability
+                )
+                if online:
                     self.context["model"] = snapmaker.model or host
                     return await self.async_step_authorize()
                 else:

--- a/custom_components/snapmaker/snapmaker.py
+++ b/custom_components/snapmaker/snapmaker.py
@@ -170,6 +170,22 @@ class SnapmakerDevice:
         )
         return False
 
+    def check_reachability(self) -> bool:
+        """Check if the device is discoverable and its API port is open.
+
+        Used by the config flow for a connectivity-only probe that does NOT
+        attempt token authentication, avoiding a spurious touchscreen prompt.
+        Sets self._model as a side effect of UDP discovery.
+
+        Returns:
+            True if the device responds to UDP discovery and the TCP API port
+            is reachable, False otherwise.
+        """
+        self._check_online()
+        if not self._available:
+            return False
+        return self._check_reachable()
+
     def _connect_with_token(self, token: str) -> bool:
         """Reconnect to the device using an existing known token.
 
@@ -483,6 +499,9 @@ class SnapmakerDevice:
                             _LOGGER.info("Token validated successfully")
                             self._token = token
                             self._token_invalid = False
+                            # Session is now established; next update() can skip
+                            # the reconnect POST and go straight to _get_status().
+                            self._connected = True
                             # Notify callback about new token for persistence
                             if self._on_token_update:
                                 self._on_token_update(token)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -65,7 +65,7 @@ class TestConfigFlow:
         self, hass, mock_snapmaker_device, mock_setup_entry
     ):
         """Test user configuration with connection error."""
-        mock_snapmaker_device.return_value.available = False
+        mock_snapmaker_device.return_value.check_reachability.return_value = False
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -83,7 +83,9 @@ class TestConfigFlow:
         self, hass, mock_snapmaker_device, mock_setup_entry
     ):
         """Test user configuration with exception."""
-        mock_snapmaker_device.return_value.update.side_effect = Exception("Test error")
+        mock_snapmaker_device.return_value.check_reachability.side_effect = Exception(
+            "Test error"
+        )
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -209,7 +211,7 @@ class TestConfigFlow:
         self, hass, mock_snapmaker_device, mock_setup_entry
     ):
         """Test DHCP discovery that needs user confirmation."""
-        mock_snapmaker_device.return_value.available = False
+        mock_snapmaker_device.return_value.check_reachability.return_value = False
 
         discovery_info = MagicMock()
         discovery_info.ip = "192.168.1.100"
@@ -287,7 +289,7 @@ class TestConfigFlow:
         assert result["step_id"] == "confirm"
 
         # Now try to confirm but device is unavailable
-        mock_snapmaker_device.return_value.available = False
+        mock_snapmaker_device.return_value.check_reachability.return_value = False
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/test_snapmaker.py
+++ b/tests/test_snapmaker.py
@@ -655,6 +655,41 @@ class TestTCPReachability:
             assert mock_sleep.call_args_list == expected_sleeps
 
 
+class TestCheckReachability:
+    """Test the public check_reachability() method."""
+
+    def test_check_reachability_online(self, mock_socket):
+        """Returns True when UDP discovery and TCP check both succeed."""
+        device = SnapmakerDevice("192.168.1.100")
+        assert device.check_reachability() is True
+
+    def test_check_reachability_offline_udp(self, mock_socket):
+        """Returns False when UDP discovery finds no device."""
+        mock_socket.recvfrom.side_effect = socket.timeout()
+        device = SnapmakerDevice("192.168.1.100")
+        assert device.check_reachability() is False
+
+    def test_check_reachability_offline_tcp(self, mock_socket):
+        """Returns False when TCP port is closed after UDP discovery succeeds."""
+        mock_socket.connect_ex.return_value = 1
+        device = SnapmakerDevice("192.168.1.100")
+        with patch("custom_components.snapmaker.snapmaker.time.sleep"):
+            assert device.check_reachability() is False
+
+    def test_check_reachability_sets_model(self, mock_socket):
+        """Sets device model as a side effect of UDP discovery."""
+        device = SnapmakerDevice("192.168.1.100")
+        device.check_reachability()
+        assert device.model == "Snapmaker A350"
+
+    def test_check_reachability_no_token_ops(self, mock_socket, mock_requests):
+        """Does not make any HTTP requests (no token operations)."""
+        device = SnapmakerDevice("192.168.1.100")
+        device.check_reachability()
+        mock_requests.post.assert_not_called()
+        mock_requests.get.assert_not_called()
+
+
 class TestTokenPersistence:
     """Test token persistence feature."""
 


### PR DESCRIPTION
## Summary
Refactored the config flow to use a new `check_reachability()` method for connectivity checks instead of full device updates. This avoids triggering unnecessary touchscreen prompts during initial device discovery and reauth flows.

## Key Changes
- **New `check_reachability()` method**: Added a public method to `SnapmakerDevice` that performs UDP discovery and TCP port checks without any token authentication or HTTP requests. This is used by the config flow for connectivity-only probes.
- **Config flow optimization**: Replaced all `snapmaker.update()` calls in discovery/confirmation steps with `snapmaker.check_reachability()` to avoid spurious authentication prompts.
- **Token generation flow improvement**: Modified the authorize step to reuse the same `SnapmakerDevice` instance after token generation. The instance's `_connected` flag is set to `True` after successful token validation, allowing the subsequent `update()` call to skip the reconnect POST and go straight to status retrieval.
- **Test coverage**: Added comprehensive tests for the new `check_reachability()` method and updated existing config flow tests to mock the new method.

## Implementation Details
- The `check_reachability()` method calls `_check_online()` (UDP discovery) followed by `_check_reachable()` (TCP port check), returning `True` only if both succeed.
- Sets `self._model` as a side effect of UDP discovery, allowing the config flow to access device model information.
- In the authorize step, after `generate_token()` succeeds and sets `_connected = True`, the subsequent `update()` call skips the token reconnect POST request, preventing a second touchscreen prompt.
- All four config flow entry points (user, dhcp, confirm, reauth_confirm) now use the connectivity-only check for initial device validation.

https://claude.ai/code/session_01GuT4tz7QvKtqizgGrZbB9m