### PR TITLE
Add tests for coverage gaps flagged by Codecov on PR #14

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -147,6 +147,56 @@ class TestConfigFlow:
             CONF_TOKEN: "test-token-123",
         }
 
+    async def test_authorize_cannot_connect_after_token_generation(
+        self, hass, mock_snapmaker_device, mock_setup_entry
+    ):
+        """Test authorize step when device becomes unreachable after token is generated."""
+        mock_snapmaker_device.return_value.generate_token.return_value = (
+            "test-token-123"
+        )
+        mock_snapmaker_device.return_value.available = (
+            False  # device gone after token gen
+        )
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.1.100"}
+        )
+        assert result["step_id"] == "authorize"
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "authorize"
+        assert result["errors"] == {"base": "cannot_connect"}
+
+    async def test_authorize_unknown_error_on_update_exception(
+        self, hass, mock_snapmaker_device, mock_setup_entry
+    ):
+        """Test authorize step when update() raises an unexpected exception."""
+        mock_snapmaker_device.return_value.generate_token.return_value = (
+            "test-token-123"
+        )
+        mock_snapmaker_device.return_value.update.side_effect = Exception(
+            "network error"
+        )
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.1.100"}
+        )
+        assert result["step_id"] == "authorize"
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "authorize"
+        assert result["errors"] == {"base": "unknown"}
+
     async def test_user_flow_already_configured(
         self, hass, mock_snapmaker_device, mock_setup_entry
     ):

--- a/tests/test_snapmaker.py
+++ b/tests/test_snapmaker.py
@@ -1032,3 +1032,29 @@ class TestTokenReconnect:
         assert mock_requests.post.call_count == 2
         assert mock_requests.get.call_count == 1
         assert device.data["tool_head"] == "Extruder"
+
+    def test_generate_token_sets_connected(self, mock_requests):
+        """generate_token() sets _connected=True so the next update() skips the reconnect POST."""
+        device = SnapmakerDevice("192.168.1.100")
+        token = device.generate_token(max_attempts=1)
+
+        assert token == "test-token-123"
+        assert device._connected is True
+
+    def test_update_after_generate_token_skips_reconnect_post(
+        self, mock_socket, mock_requests
+    ):
+        """update() must not call _connect_with_token() when _connected is already True.
+
+        After generate_token() the session is established. A second reconnect POST
+        would trigger another touchscreen prompt — the bug this flag prevents.
+        """
+        device = SnapmakerDevice("192.168.1.100")
+        device.generate_token(max_attempts=1)
+        mock_requests.reset_mock()  # clear the POSTs from generate_token
+
+        device.update()
+
+        # Only the status GET should fire — no reconnect POST
+        assert mock_requests.post.call_count == 0
+        assert mock_requests.get.call_count == 1


### PR DESCRIPTION
## Summary

Closes the three lines flagged as missing coverage by Codecov on PR #14, and adds the optimization invariant test requested in the code review.

## Test plan

- `test_generate_token_sets_connected` — verifies `self._connected = True` is set in `generate_token()` on success (covers the missing `snapmaker.py` line)
- `test_update_after_generate_token_skips_reconnect_post` — verifies that `update()` sends **zero** reconnect POSTs after `generate_token()`, locking in the "no spurious touchscreen prompt" invariant
- `test_authorize_cannot_connect_after_token_generation` — covers the `cannot_connect` branch in `async_step_authorize` when the device goes unreachable after token generation
- `test_authorize_unknown_error_on_update_exception` — covers the `unknown` error branch when `update()` raises an unexpected exception in `async_step_authorize`

https://claude.ai/code/session_01GuT4tz7QvKtqizgGrZbB9m
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuT4tz7QvKtqizgGrZbB9m)_