### PR TITLE
Fix auth flow on UDP-filtered networks

### DIFF
--- a/custom_components/snapmaker/snapmaker.py
+++ b/custom_components/snapmaker/snapmaker.py
@@ -221,10 +221,10 @@ class SnapmakerDevice:
     def update(self) -> Dict[str, Any]:
         """Update device data."""
         if not self._connected:
-            # No active session — discover device via UDP to check availability.
+            # Best-effort UDP discovery to populate self._model/self._status.
+            # Result does NOT gate the update — UDP broadcast is frequently
+            # filtered on networks with VLANs or AP isolation. TCP is authoritative.
             self._check_online()
-            if not self._available or self._status == "OFFLINE":
-                return self._data
         else:
             # Active session already established (e.g. just after generate_token()).
             # Skip UDP discovery: we know the device is there because we already
@@ -241,6 +241,9 @@ class SnapmakerDevice:
             )
             self._set_offline()
             return self._data
+
+        # TCP succeeded — device is reachable regardless of UDP outcome
+        self._available = True
 
         if self._token:
             if not self._connected:

--- a/custom_components/snapmaker/snapmaker.py
+++ b/custom_components/snapmaker/snapmaker.py
@@ -220,41 +220,48 @@ class SnapmakerDevice:
 
     def update(self) -> Dict[str, Any]:
         """Update device data."""
-        # First check if device is online via discovery
-        self._check_online()
-
-        # If device is online, get detailed status
-        if self._available and self._status != "OFFLINE":
-            # TCP reachability pre-check before making HTTP calls
-            if not self._check_reachable():
-                _LOGGER.warning(
-                    "Device %s discovered but API port %d not reachable",
-                    self._host,
-                    API_PORT,
-                )
-                self._set_offline()
+        if not self._connected:
+            # No active session — discover device via UDP to check availability.
+            self._check_online()
+            if not self._available or self._status == "OFFLINE":
                 return self._data
+        else:
+            # Active session already established (e.g. just after generate_token()).
+            # Skip UDP discovery: we know the device is there because we already
+            # have a working HTTP session. Mark available so the status check
+            # proceeds; _set_offline() will correct this if TCP fails.
+            self._available = True
 
-            if self._token:
-                if not self._connected:
-                    # Reconnect with existing token. Required after HA startup
-                    # (loading a saved token) or when the device reboots and the
-                    # session is lost. _connected is reset to False by _set_offline()
-                    # and on 401, so this POST only fires when actually needed.
-                    if not self._connect_with_token(self._token):
-                        _LOGGER.warning(
-                            "Failed to reconnect with saved token for %s, "
-                            "token may have been invalidated",
-                            self._host,
-                        )
-                        self._token_invalid = True
-                        return self._data
-                    self._connected = True
-            else:
-                self._token = self._get_token()
+        # TCP reachability pre-check before making HTTP calls
+        if not self._check_reachable():
+            _LOGGER.warning(
+                "Device %s API port %d not reachable",
+                self._host,
+                API_PORT,
+            )
+            self._set_offline()
+            return self._data
 
-            if self._token:
-                self._get_status()
+        if self._token:
+            if not self._connected:
+                # Reconnect with existing token. Required after HA startup
+                # (loading a saved token) or when the device reboots and the
+                # session is lost. _connected is reset to False by _set_offline()
+                # and on 401, so this POST only fires when actually needed.
+                if not self._connect_with_token(self._token):
+                    _LOGGER.warning(
+                        "Failed to reconnect with saved token for %s, "
+                        "token may have been invalidated",
+                        self._host,
+                    )
+                    self._token_invalid = True
+                    return self._data
+                self._connected = True
+        else:
+            self._token = self._get_token()
+
+        if self._token:
+            self._get_status()
 
         return self._data
 

--- a/custom_components/snapmaker/snapmaker.py
+++ b/custom_components/snapmaker/snapmaker.py
@@ -171,19 +171,21 @@ class SnapmakerDevice:
         return False
 
     def check_reachability(self) -> bool:
-        """Check if the device is discoverable and its API port is open.
+        """Check if the device API port is open without attempting authentication.
 
         Used by the config flow for a connectivity-only probe that does NOT
-        attempt token authentication, avoiding a spurious touchscreen prompt.
-        Sets self._model as a side effect of UDP discovery.
+        make any HTTP requests, avoiding a spurious touchscreen prompt.
+
+        UDP discovery is attempted first to populate self._model, but its
+        result does NOT gate the return value — UDP broadcast is frequently
+        filtered on networks with VLANs, AP isolation, or subnet routing.
+        TCP reachability of port 8080 is the authoritative check, since the
+        user has already supplied an explicit IP address.
 
         Returns:
-            True if the device responds to UDP discovery and the TCP API port
-            is reachable, False otherwise.
+            True if the TCP API port is reachable, False otherwise.
         """
-        self._check_online()
-        if not self._available:
-            return False
+        self._check_online()  # best-effort: populates self._model if UDP works
         return self._check_reachable()
 
     def _connect_with_token(self, token: str) -> bool:

--- a/tests/test_snapmaker.py
+++ b/tests/test_snapmaker.py
@@ -659,25 +659,30 @@ class TestCheckReachability:
     """Test the public check_reachability() method."""
 
     def test_check_reachability_online(self, mock_socket):
-        """Returns True when UDP discovery and TCP check both succeed."""
+        """Returns True when both UDP discovery and TCP check succeed."""
         device = SnapmakerDevice("192.168.1.100")
         assert device.check_reachability() is True
 
-    def test_check_reachability_offline_udp(self, mock_socket):
-        """Returns False when UDP discovery finds no device."""
+    def test_check_reachability_udp_filtered_but_tcp_open(self, mock_socket):
+        """Returns True when UDP is filtered but port 8080 is reachable.
+
+        UDP broadcast is frequently blocked on networks with VLANs or AP
+        isolation. TCP reachability is the authoritative check since the
+        user supplied an explicit IP address.
+        """
         mock_socket.recvfrom.side_effect = socket.timeout()
         device = SnapmakerDevice("192.168.1.100")
-        assert device.check_reachability() is False
+        assert device.check_reachability() is True
 
     def test_check_reachability_offline_tcp(self, mock_socket):
-        """Returns False when TCP port is closed after UDP discovery succeeds."""
+        """Returns False when TCP port 8080 is closed."""
         mock_socket.connect_ex.return_value = 1
         device = SnapmakerDevice("192.168.1.100")
         with patch("custom_components.snapmaker.snapmaker.time.sleep"):
             assert device.check_reachability() is False
 
-    def test_check_reachability_sets_model(self, mock_socket):
-        """Sets device model as a side effect of UDP discovery."""
+    def test_check_reachability_sets_model_when_udp_works(self, mock_socket):
+        """Sets device model as a side effect of UDP discovery when available."""
         device = SnapmakerDevice("192.168.1.100")
         device.check_reachability()
         assert device.model == "Snapmaker A350"

--- a/tests/test_snapmaker.py
+++ b/tests/test_snapmaker.py
@@ -34,11 +34,13 @@ class TestSnapmakerDevice:
         assert device.token == "saved-token-456"
 
     def test_update_offline_device(self, mock_socket):
-        """Test update when device is offline."""
+        """Test update when device is offline (both UDP and TCP unreachable)."""
         mock_socket.recvfrom.side_effect = socket.timeout()
+        mock_socket.connect_ex.return_value = 1  # TCP also unreachable
 
-        device = SnapmakerDevice("192.168.1.100")
-        result = device.update()
+        with patch("custom_components.snapmaker.snapmaker.time.sleep"):
+            device = SnapmakerDevice("192.168.1.100")
+            result = device.update()
 
         assert device.available is False
         assert device.status == "OFFLINE"
@@ -1063,3 +1065,51 @@ class TestTokenReconnect:
         # Only the status GET should fire — no reconnect POST
         assert mock_requests.post.call_count == 0
         assert mock_requests.get.call_count == 1
+
+    def test_update_connected_skips_udp_when_connected(
+        self, mock_socket, mock_requests
+    ):
+        """update() skips UDP discovery entirely when _connected=True.
+
+        Regression test: on UDP-filtered networks (VLANs, AP isolation), the
+        _connected=True path must never touch the UDP socket. Doing so would
+        stall the update for up to MAX_RETRIES × SOCKET_TIMEOUT seconds and
+        then incorrectly mark the device offline via _set_offline().
+        """
+        mock_socket.recvfrom.side_effect = socket.timeout()  # UDP filtered
+        device = SnapmakerDevice("192.168.1.100", token="test-token-123")
+        device._connected = True
+        device._available = True
+
+        device.update()
+
+        # No UDP sends — socket.sendto must not have been called
+        mock_socket.sendto.assert_not_called()
+        # Device stays available; status GET was issued
+        assert device.available is True
+        assert mock_requests.get.call_count == 1
+
+    def test_update_not_connected_udp_filtered_tcp_open(
+        self, mock_socket, mock_requests
+    ):
+        """update() recovers after offline when UDP is filtered but TCP is open.
+
+        When a device goes offline, _connected is reset to False. On the next
+        update() cycle, _check_online() (UDP) is called and times out on
+        UDP-filtered networks. With TCP as the authoritative check the update
+        must still proceed — connecting with the saved token and issuing a
+        status GET — rather than returning early with an offline result.
+        """
+        mock_socket.recvfrom.side_effect = socket.timeout()  # UDP filtered
+
+        device = SnapmakerDevice("192.168.1.100", token="test-token-123")
+        # Simulate the post-offline state: _connected reset by _set_offline()
+        device._connected = False
+
+        device.update()
+
+        # One reconnect POST + one status GET despite UDP timeout
+        assert mock_requests.post.call_count == 1
+        assert mock_requests.get.call_count == 1
+        assert device.available is True
+        assert device._connected is True


### PR DESCRIPTION
## Summary

- `check_reachability()` no longer requires UDP discovery to succeed — TCP connectivity to port 8080 is the authoritative check, UDP is best-effort only
- `update()` skips UDP discovery when an active session already exists (`_connected=True`), preventing false "cannot_connect" errors on networks where UDP broadcast is filtered (VLANs, AP isolation)
- `update()` no longer gates recovery on UDP in the disconnected branch (`_connected=False`) — after going offline, if UDP times out but TCP is open, the reconnect POST and status GET still fire as expected

## Problem

On networks with UDP broadcast filtering (common with VLANs or AP isolation), three auth/update flow failures occurred:

1. **"Cannot connect" on the initial config flow step** — `check_reachability()` returned `False` when UDP timed out, even if the device was reachable via TCP
2. **"Cannot connect" after touchscreen approval** — `update()` ran `_check_online()` (UDP) even with `_connected=True`, timed out, called `_set_offline()`, and set `available=False`
3. **Device permanently offline after any interruption** — when `_connected` was reset to `False` by `_set_offline()`, the next `update()` call would time out on UDP, return early, and never attempt TCP — leaving the device stuck offline on recovery

## Fix

- `check_reachability()`: UDP is now best-effort (populates `model` as a side effect if it works); TCP is the authoritative return value
- `update()` `_connected=True` branch: skip `_check_online()` entirely — the active session proves the device was reachable
- `update()` `_connected=False` branch: call `_check_online()` as best-effort but remove the early return that gated the TCP check on UDP success; add `self._available = True` after TCP confirms reachability



https://claude.ai/code/session_01GuT4tz7QvKtqizgGrZbB9m