### PR TITLE
Fix HACS/hassfest validation: sort manifest keys and declare config-entry-only schema

### DIFF
--- a/custom_components/snapmaker/__init__.py
+++ b/custom_components/snapmaker/__init__.py
@@ -21,6 +21,12 @@ PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR]
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the Snapmaker component."""
+    hass.data.setdefault(DOMAIN, {})
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Snapmaker from a config entry."""
     host = entry.data[CONF_HOST]

--- a/custom_components/snapmaker/__init__.py
+++ b/custom_components/snapmaker/__init__.py
@@ -7,6 +7,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import CONF_TOKEN, DOMAIN
@@ -17,11 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 # List of platforms to support
 PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR]
 
-
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the Snapmaker component."""
-    hass.data.setdefault(DOMAIN, {})
-    return True
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):

--- a/custom_components/snapmaker/manifest.json
+++ b/custom_components/snapmaker/manifest.json
@@ -1,14 +1,14 @@
 {
   "domain": "snapmaker",
   "name": "Snapmaker 3D Printer",
-  "version": "0.1.0",
-  "documentation": "https://github.com/conallob/homeassistant-snapmaker",
-  "dependencies": [],
   "codeowners": [
     "@conallob"
   ],
-  "requirements": [],
-  "iot_class": "local_polling",
   "config_flow": true,
-  "integration_type": "device"
+  "dependencies": [],
+  "documentation": "https://github.com/conallob/homeassistant-snapmaker",
+  "integration_type": "device",
+  "iot_class": "local_polling",
+  "requirements": [],
+  "version": "0.1.0"
 }

--- a/custom_components/snapmaker/manifest.json
+++ b/custom_components/snapmaker/manifest.json
@@ -7,9 +7,9 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/conallob/homeassistant-snapmaker",
-  "issue_tracker": "https://github.com/conallob/homeassistant-snapmaker/issues",
   "integration_type": "device",
   "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/conallob/homeassistant-snapmaker/issues",
   "requirements": [],
   "version": "0.1.0"
 }

--- a/custom_components/snapmaker/manifest.json
+++ b/custom_components/snapmaker/manifest.json
@@ -7,6 +7,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/conallob/homeassistant-snapmaker",
+  "issue_tracker": "https://github.com/conallob/homeassistant-snapmaker/issues",
   "integration_type": "device",
   "iot_class": "local_polling",
   "requirements": [],

--- a/hacs.json
+++ b/hacs.json
@@ -2,8 +2,5 @@
   "name": "Snapmaker 3D Printer",
   "content_in_root": false,
   "render_readme": true,
-  "domains": [
-    "sensor"
-  ],
   "homeassistant": "2023.8.0"
 }


### PR DESCRIPTION
## Summary

This PR fixes HACS and hassfest CI validation failures by correcting manifest metadata and declaring the integration's configuration schema properly.

## Changes

- **Added `CONFIG_SCHEMA`**: Added `CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)` alongside the existing `async_setup()`. This satisfies the HACS/hassfest requirement that integrations implementing `async_setup` must declare a config schema, and correctly signals to Home Assistant that this integration cannot be configured via YAML.
- **Added `cv` import**: Added `from homeassistant.helpers import config_validation as cv` to support the new `CONFIG_SCHEMA` declaration.
- **Sorted `manifest.json` keys**: Reordered all fields after `domain`/`name` into strict alphabetical order (`codeowners → config_flow → dependencies → documentation → integration_type → iot_class → issue_tracker → requirements → version`) as required by HACS/hassfest validation.
- **Added `issue_tracker` to `manifest.json`**: Added the required `issue_tracker` URL, which HACS validation expects to be present.
- **Removed invalid `domains` key from `hacs.json`**: The `domains` field is not a valid HACS configuration key and was causing a validation error.

https://claude.ai/code/session_01TCnQSrAYY2gpnK5Q7C88p4